### PR TITLE
Separate xpub text from QR and simplify key expression logic

### DIFF
--- a/i18n/translations/de-DE.json
+++ b/i18n/translations/de-DE.json
@@ -27,6 +27,7 @@
     "Failed to load mnemonic": "Mnemonic könnte nicht geladen werden",
     "Failed to load wallet": "Wallet könnte nicht geladen werden",
     "Fee:\n₿%s": "Gebühr:\n₿%s",
+    "Fingerprint: %s\n\nDerivation: m%s\n\n%s": "Fingerabdruck: %s\n\nAbleitung: m%s\n\n%s",
     "Firmware exceeds max size: %d": "Die Firmware übersteigt die maximale Größe: %d",
     "Go": "Go",
     "Invalid address": "Ungültige Adresse",

--- a/i18n/translations/en-US.json
+++ b/i18n/translations/en-US.json
@@ -27,6 +27,7 @@
     "Failed to load mnemonic": "Failed to load mnemonic",
     "Failed to load wallet": "Failed to load wallet",
     "Fee:\n₿%s": "Fee:\n₿%s",
+    "Fingerprint: %s\n\nDerivation: m%s\n\n%s": "Fingerprint: %s\n\nDerivation: m%s\n\n%s",
     "Firmware exceeds max size: %d": "Firmware exceeds max size: %d",
     "Go": "Go",
     "Invalid address": "Invalid address",

--- a/i18n/translations/es-MX.json
+++ b/i18n/translations/es-MX.json
@@ -27,6 +27,7 @@
     "Failed to load mnemonic": "No se puede cargar la mnemotécnica",
     "Failed to load wallet": "No se puede cargar la cartera",
     "Fee:\n₿%s": "Comisión:\n₿%s",
+    "Fingerprint: %s\n\nDerivation: m%s\n\n%s": "Huella Dactilar: %s\n\nDerivación: m%s\n\n%s",
     "Firmware exceeds max size: %d": "El firmware supera el tamaño máximo: %d",
     "Go": "Ir",
     "Invalid address": "Dirección inválida",

--- a/i18n/translations/fr-FR.json
+++ b/i18n/translations/fr-FR.json
@@ -27,6 +27,7 @@
     "Failed to load mnemonic": "Erreur de chargement mnémonique",
     "Failed to load wallet": "Erreur de chargement du portefeuille",
     "Fee:\n₿%s": "Frais:\n₿%s",
+    "Fingerprint: %s\n\nDerivation: m%s\n\n%s": "Empreinte Digitale: %s\n\nDérivation: m%s\n\n%s",
     "Firmware exceeds max size: %d": "Le micrologiciel dépasse la taille maximale: %d",
     "Go": "Go",
     "Invalid address": "Adresse invalide",

--- a/i18n/translations/vi-VN.json
+++ b/i18n/translations/vi-VN.json
@@ -27,6 +27,7 @@
     "Failed to load mnemonic": "Tải mã mnemonic thất bại",
     "Failed to load wallet": "Tải ví thất bại",
     "Fee:\n₿%s": "Phí:\n₿%s",
+    "Fingerprint: %s\n\nDerivation: m%s\n\n%s": "Dấu vân tay: %s\n\nNguồn gốc: m%s\n\n%s",
     "Firmware exceeds max size: %d": "Phần sụn vượt quá kích thước tối đa: %d",
     "Go": "Đến",
     "Invalid address": "Địa chỉ không hợp lệ",

--- a/src/krux/key.py
+++ b/src/krux/key.py
@@ -26,6 +26,7 @@ from binascii import hexlify
 from embit import bip32, bip39
 from embit.wordlists.bip39 import WORDLIST
 from embit.networks import NETWORKS
+from .i18n import t
 
 DER_SINGLE = "m/84h/%dh/0h"
 DER_MULTI = "m/48h/%dh/0h/2h"
@@ -47,50 +48,22 @@ class Key:
         ]
         self.account = self.root.derive(self.derivation).to_public()
 
-    def xpub(self):
+    def xpub(self, version=None):
         """Returns the xpub representation of the extended master public key"""
-        return self.account.to_base58()
+        return self.account.to_base58(version)
 
-    def xpub_btc_core(self):
-        """Returns the xpub of the extended master public key, prefixed with
-        fingerprint and derivation
+    def key_expression(self, version=None, pretty=False):
+        """Returns the extended master public key in key expression format
+        per https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki#key-expressions,
+        prefixed with fingerprint and derivation.
         """
-        return "[%s%s]%s" % (
-            hexlify(self.fingerprint).decode("utf-8"),
-            self.derivation[1:],  # remove leading m
-            self.account.to_base58(),
+        key_str = (
+            t("Fingerprint: %s\n\nDerivation: m%s\n\n%s") if pretty else "[%s%s]%s"
         )
-
-    def p2wsh_zpub(self):
-        """Returns the Zpub representation of the extended master public key
-        used for denoting P2WSH
-        """
-        return self.account.to_base58(self.network["Zpub"])
-
-    def p2wsh_zpub_btc_core(self):
-        """Returns the Zpub representation of the extended master public key
-        used for denoting P2WSH, prefixed with fingerprint and derivation
-        """
-        return "[%s%s]%s" % (
+        return key_str % (
             hexlify(self.fingerprint).decode("utf-8"),
             self.derivation[1:],  # remove leading m
-            self.account.to_base58(self.network["Zpub"]),
-        )
-
-    def p2wpkh_zpub(self):
-        """Returns the zpub representation of the extended master public key
-        used for denoting P2WPKH
-        """
-        return self.account.to_base58(self.network["zpub"])
-
-    def p2wpkh_zpub_btc_core(self):
-        """Returns the zpub representation of the extended master public key
-        used for denoting P2WPKH, prefixed with fingerprint and derivation
-        """
-        return "[%s%s]%s" % (
-            hexlify(self.fingerprint).decode("utf-8"),
-            self.derivation[1:],  # remove leading m
-            self.account.to_base58(self.network["zpub"]),
+            self.account.to_base58(version),
         )
 
 

--- a/src/krux/pages/home.py
+++ b/src/krux/pages/home.py
@@ -59,21 +59,16 @@ class Home(Page):
 
     def public_key(self):
         """Handler for the 'xpub' menu item"""
-        xpub = self.ctx.wallet.key.xpub_btc_core()
-        subtitle = self.ctx.wallet.key.xpub()
-        self.display_qr_codes(xpub, FORMAT_NONE, subtitle, DEFAULT_PADDING + 1)
-        self.print_qr_prompt(xpub, FORMAT_NONE)
-
-        if self.ctx.wallet.is_multisig():
-            zpub = self.ctx.wallet.key.p2wsh_zpub_btc_core()
-            subtitle = self.ctx.wallet.key.p2wsh_zpub()
-            self.display_qr_codes(zpub, FORMAT_NONE, subtitle, DEFAULT_PADDING + 1)
-            self.print_qr_prompt(zpub, FORMAT_NONE)
-        else:
-            zpub = self.ctx.wallet.key.p2wpkh_zpub_btc_core()
-            subtitle = self.ctx.wallet.key.p2wpkh_zpub()
-            self.display_qr_codes(zpub, FORMAT_NONE, subtitle, DEFAULT_PADDING + 1)
-            self.print_qr_prompt(zpub, FORMAT_NONE)
+        zpub = "Zpub" if self.ctx.wallet.key.multisig else "zpub"
+        for version in [None, self.ctx.wallet.key.network[zpub]]:
+            self.ctx.display.clear()
+            self.ctx.display.draw_centered_text(
+                self.ctx.wallet.key.key_expression(version, pretty=True)
+            )
+            self.ctx.input.wait_for_button()
+            xpub = self.ctx.wallet.key.key_expression(version)
+            self.display_qr_codes(xpub, FORMAT_NONE, None, DEFAULT_PADDING + 1)
+            self.print_qr_prompt(xpub, FORMAT_NONE)
         return MENU_CONTINUE
 
     def wallet(self):

--- a/src/krux/wallet.py
+++ b/src/krux/wallet.py
@@ -43,7 +43,7 @@ class Wallet:
         self.policy = None
         if not self.key.multisig:
             self.descriptor = Descriptor.from_string(
-                "wpkh(%s/{0,1}/*)" % self.key.xpub_btc_core()
+                "wpkh(%s/{0,1}/*)" % self.key.key_expression()
             )
             self.label = t("Single-key")
             self.policy = {"type": self.descriptor.scriptpubkey_type()}

--- a/tests/test_key.py
+++ b/tests/test_key.py
@@ -151,7 +151,7 @@ def test_xpub(mocker):
     key.account.to_base58.assert_called()
 
 
-def test_xpub_btc_core(mocker):
+def test_key_expression(mocker):
     mock_modules(mocker)
     import krux
     from krux.key import Key
@@ -159,57 +159,16 @@ def test_xpub_btc_core(mocker):
     key = Key(TEST_MNEMONIC, False)
     mocker.spy(key.account, "to_base58")
 
-    assert key.xpub_btc_core() == TEST_DERIVATION + TEST_XPUB
-    krux.key.hexlify.assert_called_with(TEST_FINGERPRINT)
-    key.account.to_base58.assert_called()
-
-
-def test_p2wsh_zpub(mocker):
-    mock_modules(mocker)
-    from krux.key import Key
-
-    key = Key(TEST_MNEMONIC, False)
-    mocker.spy(key.account, "to_base58")
-
-    assert key.p2wsh_zpub() == TEST_P2WSH_ZPUB
-    key.account.to_base58.assert_called_with(NETWORKS["test"]["Zpub"])
-
-
-def test_p2wsh_zpub_btc_core(mocker):
-    mock_modules(mocker)
-    import krux
-    from krux.key import Key
-
-    key = Key(TEST_MNEMONIC, False)
-    mocker.spy(key.account, "to_base58")
-
-    assert key.p2wsh_zpub_btc_core() == TEST_DERIVATION + TEST_P2WSH_ZPUB
-    krux.key.hexlify.assert_called_with(TEST_FINGERPRINT)
-    key.account.to_base58.assert_called_with(NETWORKS["test"]["Zpub"])
-
-
-def test_p2wpkh_zpub(mocker):
-    mock_modules(mocker)
-    from krux.key import Key
-
-    key = Key(TEST_MNEMONIC, False)
-    mocker.spy(key.account, "to_base58")
-
-    assert key.p2wpkh_zpub() == TEST_P2WPKH_ZPUB
-    key.account.to_base58.assert_called_with(NETWORKS["test"]["zpub"])
-
-
-def test_p2wpkh_zpub_btc_core(mocker):
-    mock_modules(mocker)
-    import krux
-    from krux.key import Key
-
-    key = Key(TEST_MNEMONIC, False)
-    mocker.spy(key.account, "to_base58")
-
-    assert key.p2wpkh_zpub_btc_core() == TEST_DERIVATION + TEST_P2WPKH_ZPUB
-    krux.key.hexlify.assert_called_with(TEST_FINGERPRINT)
-    key.account.to_base58.assert_called_with(NETWORKS["test"]["zpub"])
+    cases = [
+        (None, TEST_DERIVATION + TEST_XPUB),
+        (key.network["xpub"], TEST_DERIVATION + TEST_XPUB),
+        (key.network["zpub"], TEST_DERIVATION + TEST_P2WPKH_ZPUB),
+        (key.network["Zpub"], TEST_DERIVATION + TEST_P2WSH_ZPUB),
+    ]
+    for case in cases:
+        assert key.key_expression(case[0]) == case[1]
+        krux.key.hexlify.assert_called_with(TEST_FINGERPRINT)
+        key.account.to_base58.assert_called()
 
 
 def test_to_mnemonic_words(mocker):


### PR DESCRIPTION
Resolves #87 

- The `Public Key (xpub)` screen now shows:
  1. The key origin information (fingerprint + derivation) followed by the xpub, collectively referred to as the "key expression"
  2. The QR code of the key expression
  3. Same as the first screen, except the xpub has been converted to a zpub for wallets that can't parse a full key expression
  4. The QR code of the key expression